### PR TITLE
Remove all implicit panics from using a string key in HeaderMap

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -76,6 +76,8 @@ mod value;
 
 pub use self::map::{
     HeaderMap,
+    AsHeaderName,
+    IntoHeaderName,
     Iter,
     Keys,
     Values,
@@ -87,7 +89,6 @@ pub use self::map::{
     ValueIter,
     ValueIterMut,
     ValueDrain,
-    HeaderMapKey,
     IntoIter,
 };
 pub use self::name::{

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1695,6 +1695,15 @@ impl<'a> HdrName<'a> {
         let hdr = parse_hdr(hdr, &mut buf)?;
         Ok(f(hdr))
     }
+
+    pub fn from_static<F, U>(hdr: &'static str, f: F) -> U
+        where F: FnOnce(HdrName) -> U,
+    {
+        let mut buf = unsafe { mem::uninitialized() };
+        let hdr = parse_hdr(hdr.as_bytes(), &mut buf)
+            .expect("static str is invalid name");
+        f(hdr)
+    }
 }
 
 #[doc(hidden)]

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1586,6 +1586,14 @@ impl<'a> PartialEq<&'a HeaderName> for HeaderName {
     }
 }
 
+
+impl<'a> PartialEq<HeaderName> for &'a HeaderName {
+    #[inline]
+    fn eq(&self, other: &HeaderName) -> bool {
+        *other == *self
+    }
+}
+
 impl PartialEq<str> for HeaderName {
     /// Performs a case-insensitive comparison of the string against the header
     /// name
@@ -1593,15 +1601,35 @@ impl PartialEq<str> for HeaderName {
     /// # Examples
     ///
     /// ```
-    /// use http::*;
+    /// use http::header::CONTENT_LENGTH;
     ///
-    /// assert_eq!(header::CONTENT_LENGTH, "content-length");
-    /// assert_eq!(header::CONTENT_LENGTH, "Content-Length");
-    /// assert_ne!(header::CONTENT_LENGTH, "content length");
+    /// assert_eq!(CONTENT_LENGTH, "content-length");
+    /// assert_eq!(CONTENT_LENGTH, "Content-Length");
+    /// assert_ne!(CONTENT_LENGTH, "content length");
     /// ```
     #[inline]
     fn eq(&self, other: &str) -> bool {
         eq_ignore_ascii_case(self.as_ref(), other.as_bytes())
+    }
+}
+
+
+impl PartialEq<HeaderName> for str {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http::header::CONTENT_LENGTH;
+    ///
+    /// assert_eq!(CONTENT_LENGTH, "content-length");
+    /// assert_eq!(CONTENT_LENGTH, "Content-Length");
+    /// assert_ne!(CONTENT_LENGTH, "content length");
+    /// ```
+    #[inline]
+    fn eq(&self, other: &HeaderName) -> bool {
+        *other == *self
     }
 }
 
@@ -1611,6 +1639,16 @@ impl<'a> PartialEq<&'a str> for HeaderName {
     #[inline]
     fn eq(&self, other: &&'a str) -> bool {
         *self == **other
+    }
+}
+
+
+impl<'a> PartialEq<HeaderName> for &'a str {
+    /// Performs a case-insensitive comparison of the string against the header
+    /// name
+    #[inline]
+    fn eq(&self, other: &HeaderName) -> bool {
+        *other == *self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,12 @@
 //!
 //! ```
 //! use http::Response;
-//! use http::header::HeaderValue;
+//! use http::header::{CONTENT_TYPE, HeaderValue};
 //! use http::status;
 //!
 //! fn add_server_headers<T>(response: &mut Response<T>) {
 //!     response.headers_mut()
-//!         .insert("Content-Type", HeaderValue::from_static("text/html"));
+//!         .insert(CONTENT_TYPE, HeaderValue::from_static("text/html"));
 //!     *response.status_mut() = status::OK;
 //! }
 //! ```


### PR DESCRIPTION
- Splits `HeaderMapKey` into `IntoHeaderName` and `AsHeaderName`.
- `IntoHeaderName` is a bounds on `insert` and `append`. It is only
  implemented for `HeaderName` and `&HeaderName`, since those are
  infallible conversions, so `insert`/`append` won't panic, nor do they
  need to change to return a `Result`.
- `AsHeaderName` is the bounds on `get`, `get_mut`, `contains_key`, etc.
  Any method that is just used for searching. The trait is implemented
  for `HeaderName` and for `str` variants, but they no longer panic on
  invalid string names. It simply returns `None` as the illegal header
  clearly is not in the map.
- `entry` has been changed because of this. The reason to use `entry` is
  to prevent unnecessary work if the key already exists in the map. So,
  it has a `AsHeaderName` bounds, to allow the searching to use a `&str`
  without having to allocate a `HeaderName`. If not found, and the string is
  valid, then it can allocate and insert. Because the parsing can fail,
  `entry` now returns a `Result<Entry<T>, InvalidHeaderName>`.

This also makes a possible controversial change: it removes public
export of these traits. The reason: We don't want anyone to actually
name this trait. We want to able to change the trait around as needed.
This can include the name of the traits.

The downside to not exporting them is that rustdoc won't document it,
and so people who really want to dig in the docs won't be able to find
what types concretely implement these traits.

The downside can be alleviated by updating the docs otherwise, or with a
change in rustdoc.

-----

This is a different attempt of fixing #72. The first version can be seen at #84.