### PR TITLE
Fixed try_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -80,7 +80,7 @@ impl HeaderValue {
     ///
     /// If the argument contains invalid header value characters, an error is
     /// returned. Only visible ASCII characters (32-127) are permitted. Use
-    /// `try_from_bytes` to create a `HeaderValue` that includes opaque octets
+    /// `from_bytes` to create a `HeaderValue` that includes opaque octets
     /// (128-255).
     ///
     /// This function is intended to be replaced in the future by a `TryFrom`
@@ -90,7 +90,7 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_str("hello").unwrap();
+    /// let val = HeaderValue::from_str("hello").unwrap();
     /// assert_eq!(val, "hello");
     /// ```
     ///
@@ -98,12 +98,12 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_str("\n");
+    /// let val = HeaderValue::from_str("\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn try_from_str(src: &str) -> Result<HeaderValue, InvalidHeaderValue> {
-        HeaderValue::try_from(src)
+    pub fn from_str(src: &str) -> Result<HeaderValue, InvalidHeaderValue> {
+        HeaderValue::from(src)
     }
 
     /// Attempt to convert a byte slice to a `HeaderValue`.
@@ -119,7 +119,7 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_bytes(b"hello\xfa").unwrap();
+    /// let val = HeaderValue::from_bytes(b"hello\xfa").unwrap();
     /// assert_eq!(val, &b"hello\xfa"[..]);
     /// ```
     ///
@@ -127,12 +127,12 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_bytes(b"\n");
+    /// let val = HeaderValue::from_bytes(b"\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn try_from_bytes(src: &[u8]) -> Result<HeaderValue, InvalidHeaderValue> {
-        HeaderValue::try_from(src)
+    pub fn from_bytes(src: &[u8]) -> Result<HeaderValue, InvalidHeaderValue> {
+        HeaderValue::from(src)
     }
 
     /// Attempt to convert a `Bytes` buffer to a `HeaderValue`.
@@ -144,11 +144,11 @@ impl HeaderValue {
     /// This function is intended to be replaced in the future by a `TryFrom`
     /// implementation once the trait is stabilized in std.
     #[inline]
-    pub fn try_from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
-        HeaderValue::try_from(src).map_err(InvalidHeaderValueBytes)
+    pub fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
+        HeaderValue::from(src).map_err(InvalidHeaderValueBytes)
     }
 
-    fn try_from<T: AsRef<[u8]> + Into<Bytes>>(src: T) -> Result<HeaderValue, InvalidHeaderValue> {
+    fn from<T: AsRef<[u8]> + Into<Bytes>>(src: T) -> Result<HeaderValue, InvalidHeaderValue> {
         for &b in src.as_ref() {
             if !is_valid(b) {
                 return Err(InvalidHeaderValue {
@@ -301,7 +301,7 @@ impl FromStr for HeaderValue {
 
     #[inline]
     fn from_str(s: &str) -> Result<HeaderValue, Self::Err> {
-        HeaderValue::try_from_str(s)
+        HeaderValue::from_str(s)
     }
 }
 
@@ -326,7 +326,7 @@ impl<'a> HttpTryFrom<&'a [u8]> for HeaderValue {
 
     #[inline]
     fn try_from(t: &'a [u8]) -> Result<Self, Self::Error> {
-        HeaderValue::try_from_bytes(t)
+        HeaderValue::from_bytes(t)
     }
 }
 
@@ -335,7 +335,7 @@ impl HttpTryFrom<Bytes> for HeaderValue {
 
     #[inline]
     fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        HeaderValue::try_from_shared(bytes)
+        HeaderValue::from_shared(bytes)
     }
 }
 
@@ -556,6 +556,6 @@ impl<'a> PartialOrd<HeaderValue> for &'a str {
 }
 
 #[test]
-fn test_try_from() {
-    HeaderValue::try_from(vec![127]).unwrap_err();
+fn test_from() {
+    HeaderValue::from(vec![127]).unwrap_err();
 }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -240,13 +240,13 @@ impl Uri {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("http://example.com/foo");
-    /// let uri = Uri::try_from_shared(bytes).unwrap();
+    /// let uri = Uri::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(uri.host().unwrap(), "example.com");
     /// assert_eq!(uri.path(), "/foo");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
         use self::ErrorKind::*;
 
         if s.len() > MAX_LEN {
@@ -274,7 +274,7 @@ impl Uri {
                         });
                     }
                     _ => {
-                        let authority = try!(Authority::try_from_shared(s));
+                        let authority = try!(Authority::from_shared(s));
 
                         return Ok(Uri {
                             scheme: Scheme::empty(),
@@ -292,7 +292,7 @@ impl Uri {
             return Ok(Uri {
                 scheme: Scheme::empty(),
                 authority: Authority::empty(),
-                origin_form: try!(OriginForm::try_from_shared(s)),
+                origin_form: try!(OriginForm::from_shared(s)),
             });
         }
 
@@ -599,7 +599,7 @@ impl HttpTryFrom<Bytes> for Uri {
 
     #[inline]
     fn try_from(t: Bytes) -> Result<Self, Self::Error> {
-        Uri::try_from_shared(t)
+        Uri::from_shared(t)
     }
 }
 
@@ -725,12 +725,12 @@ impl Scheme {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("http");
-    /// let scheme = Scheme::try_from_shared(bytes).unwrap();
+    /// let scheme = Scheme::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(scheme.as_str(), "http");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
         use self::Scheme2::*;
 
         match try!(Scheme2::parse_exact(&s[..]).map_err(InvalidUriBytes)) {
@@ -938,12 +938,12 @@ impl Authority {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("example.com");
-    /// let authority = Authority::try_from_shared(bytes).unwrap();
+    /// let authority = Authority::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(authority.host(), "example.com");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
         let authority_end = try!(Authority::parse(&s[..]).map_err(InvalidUriBytes));
 
         if authority_end != s.len() {
@@ -1076,13 +1076,13 @@ impl OriginForm {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("/hello?world");
-    /// let origin_form = OriginForm::try_from_shared(bytes).unwrap();
+    /// let origin_form = OriginForm::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(origin_form.path(), "/hello");
     /// assert_eq!(origin_form.query(), Some("world"));
     /// # }
     /// ```
-    pub fn try_from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
         let mut query = NONE;
 
         for i in 0..src.len() {
@@ -1225,7 +1225,7 @@ impl FromStr for OriginForm {
     type Err = InvalidUri;
 
     fn from_str(s: &str) -> Result<Self, InvalidUri> {
-        OriginForm::try_from_shared(s.into()).map_err(|e| e.0)
+        OriginForm::from_shared(s.into()).map_err(|e| e.0)
     }
 }
 
@@ -1310,7 +1310,7 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUriBytes> {
     Ok(Uri {
         scheme: scheme.into(),
         authority: authority,
-        origin_form: try!(OriginForm::try_from_shared(s)),
+        origin_form: try!(OriginForm::from_shared(s)),
     })
 }
 
@@ -1335,7 +1335,7 @@ impl FromStr for Uri {
 
     #[inline]
     fn from_str(s: &str) -> Result<Uri, InvalidUri> {
-        Uri::try_from_shared(s.into()).map_err(|e| e.0)
+        Uri::from_shared(s.into()).map_err(|e| e.0)
     }
 }
 

--- a/tests/header_map_fuzz.rs
+++ b/tests/header_map_fuzz.rs
@@ -354,7 +354,7 @@ fn gen_header_name(g: &mut StdRng) -> HeaderName {
 
 fn gen_header_value(g: &mut StdRng) -> HeaderValue {
     let value = gen_string(g, 0, 70);
-    HeaderValue::try_from_bytes(value.as_bytes()).unwrap()
+    HeaderValue::from_bytes(value.as_bytes()).unwrap()
 }
 
 fn gen_string(g: &mut StdRng, min: usize, max: usize) -> String {


### PR DESCRIPTION
Should fix https://github.com/carllerche/http/issues/98

I made two choices:
- Every public method is NOT prefix with `try_` in order to be more in line with other similar Rust implementation 
- I let the `try_`for every implementation of `HttpTryFrom` because it wants to mirror `TryFrom` which itself has a method named `try_from`

If it's not enough, just let me know.