### PR TITLE
add HeaderValue::from_shared_unchecked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ serde_json = "1.0"
 [[bench]]
 name = "header_map"
 path = "benches/header_map/mod.rs"
+
+[[bench]]
+name = "header_value"
+path = "benches/header_value.rs"

--- a/benches/header_value.rs
+++ b/benches/header_value.rs
@@ -1,0 +1,54 @@
+#![feature(test)]
+
+extern crate bytes;
+extern crate http;
+extern crate test;
+
+use bytes::Bytes;
+use http::header::HeaderValue;
+use test::Bencher;
+
+static SHORT: &'static [u8] = b"localhost";
+static LONG: &'static [u8] = b"Mozilla/5.0 (X11; CrOS x86_64 9592.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.80 Safari/537.36";
+
+
+#[bench]
+fn try_from_shared_short(b: &mut Bencher) {
+    b.bytes = SHORT.len() as u64;
+    let bytes = Bytes::from_static(SHORT);
+    b.iter(|| {
+        HeaderValue::try_from_shared(bytes.clone()).unwrap();
+    });
+}
+
+#[bench]
+fn try_from_shared_long(b: &mut Bencher) {
+    b.bytes = LONG.len() as u64;
+    let bytes = Bytes::from_static(LONG);
+    b.iter(|| {
+        HeaderValue::try_from_shared(bytes.clone()).unwrap();
+    });
+}
+
+
+#[bench]
+fn from_shared_unchecked_short(b: &mut Bencher) {
+    b.bytes = SHORT.len() as u64;
+    let bytes = Bytes::from_static(SHORT);
+    b.iter(|| {
+        unsafe {
+            HeaderValue::from_shared_unchecked(bytes.clone());
+        }
+    });
+}
+
+#[bench]
+fn from_shared_unchecked_long(b: &mut Bencher) {
+    b.bytes = LONG.len() as u64;
+    let bytes = Bytes::from_static(LONG);
+    b.iter(|| {
+        unsafe {
+            HeaderValue::from_shared_unchecked(bytes.clone());
+        }
+    });
+}

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -148,6 +148,18 @@ impl HeaderValue {
         HeaderValue::try_from(src).map_err(InvalidHeaderValueBytes)
     }
 
+    /// Convert a `Bytes` directly into a `HeaderValue` without validating.
+    ///
+    /// This function does NOT validate that illegal bytes are not contained
+    /// within the buffer.
+    #[inline]
+    pub unsafe fn from_shared_unchecked(src: Bytes) -> HeaderValue {
+        HeaderValue {
+            inner: src,
+            is_sensitive: false,
+        }
+    }
+
     fn try_from<T: AsRef<[u8]> + Into<Bytes>>(src: T) -> Result<HeaderValue, InvalidHeaderValue> {
         for &b in src.as_ref() {
             if !is_valid(b) {


### PR DESCRIPTION
The reason for wanting this is to prevent double parsing a header value. For example, in hyper, the bytes are parsed using httparse, which already verifies the header values do not contain illegal values.

There's a technicality issue here: it's not actually `unsafe`, according to Rust's strict definition of `unsafe` meaning memory unsafety. These bytes are never converted into a `str` without validating them first.

At the same time, it is totally unsafe in a HTTP context...