### PR TITLE
customize Debug for request/response Parts

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -164,7 +164,6 @@ pub struct Request<T> {
 ///
 /// The HTTP request head consists of a method, uri, version, and a set of
 /// header fields.
-#[derive(Debug)]
 pub struct Parts {
     /// The request's method
     pub method: Method,
@@ -483,6 +482,19 @@ impl Parts {
             extensions: Extensions::default(),
             _priv: (),
         }
+    }
+}
+
+impl fmt::Debug for Parts {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Parts")
+            .field("method", &self.method)
+            .field("uri", &self.uri)
+            .field("version", &self.version)
+            .field("headers", &self.headers)
+            // omits Extensions because not useful
+            // omits _priv because not useful
+            .finish()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -191,7 +191,6 @@ pub struct Response<T> {
 ///
 /// The HTTP response head consists of a status, version, and a set of
 /// header fields.
-#[derive(Debug)]
 pub struct Parts {
     /// The response's status
     pub status: StatusCode,
@@ -478,6 +477,18 @@ impl Parts {
             extensions: Extensions::default(),
             _priv: (),
         }
+    }
+}
+
+impl fmt::Debug for Parts {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Parts")
+            .field("status", &self.status)
+            .field("version", &self.version)
+            .field("headers", &self.headers)
+            // omits Extensions because not useful
+            // omits _priv because not useful
+            .finish()
     }
 }
 


### PR DESCRIPTION
Seeing `extensions: Extensions, _priv: ()` just adds noise around the parts you want to see. So this removes those.