### PR TITLE
convert all inherent try_from_* functions to from_*

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -80,7 +80,7 @@ impl HeaderValue {
     ///
     /// If the argument contains invalid header value characters, an error is
     /// returned. Only visible ASCII characters (32-127) are permitted. Use
-    /// `try_from_bytes` to create a `HeaderValue` that includes opaque octets
+    /// `from_bytes` to create a `HeaderValue` that includes opaque octets
     /// (128-255).
     ///
     /// This function is intended to be replaced in the future by a `TryFrom`
@@ -90,7 +90,7 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_str("hello").unwrap();
+    /// let val = HeaderValue::from_str("hello").unwrap();
     /// assert_eq!(val, "hello");
     /// ```
     ///
@@ -98,11 +98,11 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_str("\n");
+    /// let val = HeaderValue::from_str("\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn try_from_str(src: &str) -> Result<HeaderValue, InvalidHeaderValue> {
+    pub fn from_str(src: &str) -> Result<HeaderValue, InvalidHeaderValue> {
         HeaderValue::try_from(src)
     }
 
@@ -119,7 +119,7 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_bytes(b"hello\xfa").unwrap();
+    /// let val = HeaderValue::from_bytes(b"hello\xfa").unwrap();
     /// assert_eq!(val, &b"hello\xfa"[..]);
     /// ```
     ///
@@ -127,11 +127,11 @@ impl HeaderValue {
     ///
     /// ```
     /// # use http::header::HeaderValue;
-    /// let val = HeaderValue::try_from_bytes(b"\n");
+    /// let val = HeaderValue::from_bytes(b"\n");
     /// assert!(val.is_err());
     /// ```
     #[inline]
-    pub fn try_from_bytes(src: &[u8]) -> Result<HeaderValue, InvalidHeaderValue> {
+    pub fn from_bytes(src: &[u8]) -> Result<HeaderValue, InvalidHeaderValue> {
         HeaderValue::try_from(src)
     }
 
@@ -144,7 +144,7 @@ impl HeaderValue {
     /// This function is intended to be replaced in the future by a `TryFrom`
     /// implementation once the trait is stabilized in std.
     #[inline]
-    pub fn try_from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
+    pub fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
         HeaderValue::try_from(src).map_err(InvalidHeaderValueBytes)
     }
 
@@ -301,7 +301,7 @@ impl FromStr for HeaderValue {
 
     #[inline]
     fn from_str(s: &str) -> Result<HeaderValue, Self::Err> {
-        HeaderValue::try_from_str(s)
+        HeaderValue::from_str(s)
     }
 }
 
@@ -326,7 +326,7 @@ impl<'a> HttpTryFrom<&'a [u8]> for HeaderValue {
 
     #[inline]
     fn try_from(t: &'a [u8]) -> Result<Self, Self::Error> {
-        HeaderValue::try_from_bytes(t)
+        HeaderValue::from_bytes(t)
     }
 }
 
@@ -335,7 +335,7 @@ impl HttpTryFrom<Bytes> for HeaderValue {
 
     #[inline]
     fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        HeaderValue::try_from_shared(bytes)
+        HeaderValue::from_shared(bytes)
     }
 }
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -240,13 +240,13 @@ impl Uri {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("http://example.com/foo");
-    /// let uri = Uri::try_from_shared(bytes).unwrap();
+    /// let uri = Uri::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(uri.host().unwrap(), "example.com");
     /// assert_eq!(uri.path(), "/foo");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
         use self::ErrorKind::*;
 
         if s.len() > MAX_LEN {
@@ -274,7 +274,7 @@ impl Uri {
                         });
                     }
                     _ => {
-                        let authority = Authority::try_from_shared(s)?;
+                        let authority = Authority::from_shared(s)?;
 
                         return Ok(Uri {
                             scheme: Scheme::empty(),
@@ -292,7 +292,7 @@ impl Uri {
             return Ok(Uri {
                 scheme: Scheme::empty(),
                 authority: Authority::empty(),
-                path_and_query: PathAndQuery::try_from_shared(s)?,
+                path_and_query: PathAndQuery::from_shared(s)?,
             });
         }
 
@@ -597,7 +597,7 @@ impl HttpTryFrom<Bytes> for Uri {
 
     #[inline]
     fn try_from(t: Bytes) -> Result<Self, Self::Error> {
-        Uri::try_from_shared(t)
+        Uri::from_shared(t)
     }
 }
 
@@ -723,12 +723,12 @@ impl Scheme {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("http");
-    /// let scheme = Scheme::try_from_shared(bytes).unwrap();
+    /// let scheme = Scheme::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(scheme.as_str(), "http");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
         use self::Scheme2::*;
 
         match Scheme2::parse_exact(&s[..]).map_err(InvalidUriBytes)? {
@@ -936,12 +936,12 @@ impl Authority {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("example.com");
-    /// let authority = Authority::try_from_shared(bytes).unwrap();
+    /// let authority = Authority::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(authority.host(), "example.com");
     /// # }
     /// ```
-    pub fn try_from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
         let authority_end = Authority::parse(&s[..]).map_err(InvalidUriBytes)?;
 
         if authority_end != s.len() {
@@ -1074,13 +1074,13 @@ impl PathAndQuery {
     ///
     /// # pub fn main() {
     /// let bytes = Bytes::from("/hello?world");
-    /// let path_and_query = PathAndQuery::try_from_shared(bytes).unwrap();
+    /// let path_and_query = PathAndQuery::from_shared(bytes).unwrap();
     ///
     /// assert_eq!(path_and_query.path(), "/hello");
     /// assert_eq!(path_and_query.query(), Some("world"));
     /// # }
     /// ```
-    pub fn try_from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub fn from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
         let mut query = NONE;
 
         for i in 0..src.len() {
@@ -1223,7 +1223,7 @@ impl FromStr for PathAndQuery {
     type Err = InvalidUri;
 
     fn from_str(s: &str) -> Result<Self, InvalidUri> {
-        PathAndQuery::try_from_shared(s.into()).map_err(|e| e.0)
+        PathAndQuery::from_shared(s.into()).map_err(|e| e.0)
     }
 }
 
@@ -1308,7 +1308,7 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUriBytes> {
     Ok(Uri {
         scheme: scheme.into(),
         authority: authority,
-        path_and_query: PathAndQuery::try_from_shared(s)?,
+        path_and_query: PathAndQuery::from_shared(s)?,
     })
 }
 
@@ -1333,7 +1333,7 @@ impl FromStr for Uri {
 
     #[inline]
     fn from_str(s: &str) -> Result<Uri, InvalidUri> {
-        Uri::try_from_shared(s.into()).map_err(|e| e.0)
+        Uri::from_shared(s.into()).map_err(|e| e.0)
     }
 }
 

--- a/tests/header_map_fuzz.rs
+++ b/tests/header_map_fuzz.rs
@@ -354,7 +354,7 @@ fn gen_header_name(g: &mut StdRng) -> HeaderName {
 
 fn gen_header_value(g: &mut StdRng) -> HeaderValue {
     let value = gen_string(g, 0, 70);
-    HeaderValue::try_from_bytes(value.as_bytes()).unwrap()
+    HeaderValue::from_bytes(value.as_bytes()).unwrap()
 }
 
 fn gen_string(g: &mut StdRng, min: usize, max: usize) -> String {


### PR DESCRIPTION
~~Some places use `from_u16`, others use `try_from_bytes`, this PR unifies the pattern. It settled on `try_from_*` for these reasons:~~

- ~~There exists a few functions, like `from_static`, which don't return a `Result`.~~
- ~~While there are several cases in std, like `from_utf8`, `from_str`, it's also inconsistent within std, with things like `Duration::from_secs() -> Duration`.~~
- ~~It lines up closer with the eventual `TryFrom::try_from`.~~

Updated to do the reverse.

Closes #98 