### PR TITLE
HeaderMap::get_all() returns a GetAll instead of an Option

### DIFF
--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -216,8 +216,9 @@ fn append_multiple_values() {
     map.append(header::CONTENT_TYPE, "html");
     map.append(header::CONTENT_TYPE, "xml");
 
-    let vals = map.get_all(&header::CONTENT_TYPE).unwrap();
-    let vals: Vec<_> = vals.iter().collect();
+    let vals = map.get_all(&header::CONTENT_TYPE)
+        .iter()
+        .collect::<Vec<_>>();
 
     assert_eq!(&vals, &[&"json", &"html", &"xml"]);
 }

--- a/tests/header_map_fuzz.rs
+++ b/tests/header_map_fuzz.rs
@@ -239,7 +239,7 @@ impl AltMap {
             assert_eq!(other.get(key), val.get(0));
 
             // Test get_all
-            let vals = other.get_all(key).unwrap();
+            let vals = other.get_all(key);
             let actual: Vec<_> = vals.iter().collect();
             assert_eq!(&actual[..], &val[..]);
         }
@@ -255,9 +255,7 @@ impl Action {
             }
             Action::Remove { name, val } => {
                 // Just to help track the state, load all associated values.
-                if let Some(v) = map.get_all(&name) {
-                    let _: Vec<_> = v.iter().collect();
-                }
+                map.get_all(&name).iter().collect::<Vec<_>>();
 
                 let actual = map.remove(&name);
                 assert_eq!(actual, val);


### PR DESCRIPTION
Also removes `key()` and `get()` from `GetAll`.

Closes #111 